### PR TITLE
feat: add support for non-writable storages in cleanup commands

### DIFF
--- a/Classes/Command/Cleanup/AbstractCleanupCommand.php
+++ b/Classes/Command/Cleanup/AbstractCleanupCommand.php
@@ -208,6 +208,13 @@ class AbstractCleanupCommand extends AbstractCommand
     public function logFailed(string $logFileFailed, string $file): void
     {
         $this->io->writeln('<error>Failed to delete file, it might still have references</error>');
+
+        // Ensure log directory exists
+        $logDirectory = dirname($logFileFailed);
+        if (!is_dir($logDirectory) && !mkdir($logDirectory, 0775, true) && !is_dir($logDirectory)) {
+            throw new \RuntimeException(sprintf('Directory "%s" was not created', $logDirectory));
+        }
+
         file_put_contents($logFileFailed, $file . PHP_EOL, FILE_APPEND | LOCK_EX);
     }
 

--- a/Classes/Service/FileOperationService.php
+++ b/Classes/Service/FileOperationService.php
@@ -38,7 +38,7 @@ class FileOperationService
     /**
      * Delete a file via the TYPO3 API
      *
-     * @param string $identifier Path or identifier of the file to delete
+     * @param string $identifier Uid or Path or identifier of the file to delete
      * @param int $storageId ID of the storage containing the file
      * @return bool Success status of the deletion
      */
@@ -49,7 +49,7 @@ class FileOperationService
         }
 
         if ($this->io->isDebug()) {
-            $this->io->writeln('Executing delete command with data path: ' . $identifier);
+            $this->io->writeln('Executing delete command with data uid: ' . $identifier);
         }
 
         $result = $this->executeCommand([

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ Be aware that the cleanup commands may move files to the recycle bins (`_recycle
 [appropriate TYPO3 scheduler task.](https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/Installation/BaseTasks/Index.html)
 to delete those files automatically.
 
+### Writable Storage Support
+
+All cleanup commands automatically detect **writable vs. non-writable storages** and adapt their behavior:
+
+- **Writable storages**: Creates dummy files before deletion (standard behavior)
+- **Non-writable storages**: Skips local file operations and deletes directly via TYPO3 FAL API
+
+The storage type is determined by checking `isWritable()`.
+
 ### Files Cleanup Command
 
 Cleanup files via a given identifier. All files matching the given string are deleted via the


### PR DESCRIPTION
This change enables cleanup commands to work with non-writable storages (e.g., read-only mounts, S3, cloud storage) by detecting storage writeability and skipping local file operations when necessary.

## Problems Fixed

1. **Non-writable Storage Handling**
   - Commands failed on read-only storages trying to create dummy files
   - Local file operations (touch, mkdir, unlink) are now skipped for non-writable storages
   - Detection via `$storage->isWritable()` method

2. **Invalid Storage Path**
   - `getPublicUrl()` used in `AbstractCleanupCommand::getFullStoragePath()` returns a URL (e.g., https://cdn.example.com/files/) when storage has a baseUri set (e.g., with core config or andersundsehr/aus-driver-amazon-s3)
   - This caused invalid file paths when concatenating with local paths
   - This caused invalid identifiers used to delete files > better use the uid of the record
   - Storage path is now only populated for writable storages

## Changes

- **AbstractCleanupCommand**: Added `isWritableStorage` property and detection logic in `prepareExecution()`
- **MissingFilesCleanupCommand**: Skip `touchFile()` for non-writable storages in `beforeFileDelete()`, skip `file_exists()` checks conditionally
- **FilesCleanupCommand**: Skip `file_exists()` checks and `removeEmptyFolder()` for non-writable storages
- **All Commands**: Use file UID instead of identifier for deletion via `deleteFile((string)$record['uid'])`
- **README**: Added "Writable Storage Support" section documenting the new behavior

## Compatibility

- Fully backward compatible - writable storages work exactly as before
- Non-writable storages now work correctly instead of failing
- TYPO3 12.4 and 13.4 compatible